### PR TITLE
Bump lxml and python-dateutil dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Changed
 - Test factories and other test files are now included in the package installation. Factories can be useful when creating project tests.
+- Bump allowed `lxml` to 3.6.0
+- Bump allowed `python-dateutil` to 2.5.3
 
 ### Fixes
 - Don't raise on Post.tags if Post.raw_content is None

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "lxml>=3.4.4, <=3.6.0",
         "jsonschema==2.5.1",
         "pycrypto==2.6.1",
-        "python-dateutil==2.4.2",
+        "python-dateutil>=2.4.2, <=2.5.3",
         "python-xrd==0.1",
     ],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     license="BSD 3-clause",
     install_requires=[
         "dirty-validators==0.3.2",
-        "lxml==3.4.4",
+        "lxml>=3.4.4, <=3.6.0",
         "jsonschema==2.5.1",
         "pycrypto==2.6.1",
         "python-dateutil==2.4.2",


### PR DESCRIPTION
Loosen them at the same time.