### PR TITLE
Refactor Diaspora protocol sender handle fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Changed
 - Unlock most of the direct dependencies to a certain version range. Unlock all of test requirements to any version.
 
+### Fixes
+- Fix fetching sender handle from Diaspora protocol private messages. As it is not contained in the header, it needs to be read from the message content itself.
+
 ## [0.3.2] - 2016-05-09
 
 ### Changed

--- a/federation/tests/fixtures/payloads.py
+++ b/federation/tests/fixtures/payloads.py
@@ -3,7 +3,12 @@
 ENCRYPTED_DIASPORA_PAYLOAD = """<?xml version='1.0'?>
             <diaspora xmlns="https://joindiaspora.com/protocol" xmlns:me="http://salmon-protocol.org/ns/magic-env">
                 <encrypted_header>{encrypted_header}</encrypted_header>
-                <content />
+                <me:env>
+                    <me:data type='application/xml'>{data}</me:data>
+                    <me:encoding>base64url</me:encoding>
+                    <me:alg>RSA-SHA256</me:alg>
+                    <me:sig>{signature}</me:sig>
+                </me:env>
             </diaspora>
         """
 


### PR DESCRIPTION
Diaspora private messages don't have a plain text sender handle in the header. One must first
open the message (without verifying it), fetch the sender handle and then verify the content.

Closes #21

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaywink/social-federation/25)
<!-- Reviewable:end -->
