### PR TITLE
Get remote profile method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `Profile` base entity and Diaspora counterpart `DiasporaProfile`. Represents a user profile.
 - `federation.utils.network.fetch_document` utility function to fetch a remote document. Returns document, status code and possible exception. Takes either `url` or a `host` + `path` combination. With `host`, https is first tried and optionally fall back to http.
 - Utility methods to retrieve Diaspora user discovery related documents. These include the host-meta, webfinger and hCard documents. The utility methods are in `federation.utils.diaspora`.
+- Utility to fetch remote profile, `federation.fetchers.retrieve_remote_profile`. Currently always uses Diaspora protocol. Returns a `Profile` entity.
 
 ## Changed
 - Unlock most of the direct dependencies to a certain version range. Unlock all of test requirements to any version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - While in early stages, doing some renaming of modules to suit the longer term. `federation.controllers` has been split into two, `federation.outbound` and `federation.inbound`. The following methods have new import locations:
    * `federation.controllers.handle_receive` -> `federation.inbound.handle_receive`
    * `federation.controllers.handle_create_payload` -> `federation.outbound.handle_create_payload`
+- Class `federation.hostmeta.generators.DiasporaHCard` now requires `guid`, `public_key` and `username` for initialization. Leaving these out was a mistake in the initial implementation. Diaspora has these in at least 0.6 development branch.
 
 ## Added
 - `Relationship` base entity which represents relationships between two handles. Types can be following, sharing, ignoring and blocking. The Diaspora counterpart, `DiasporaRequest`, which represents a sharing/following request is outwards a single entity, but incoming a double entity, handled by creating both a sharing and following version of  the relationship.
@@ -17,6 +18,7 @@
 
 ### Fixes
 - Fix fetching sender handle from Diaspora protocol private messages. As it is not contained in the header, it needs to be read from the message content itself.
+- Fix various issues with `DiasporaHCard` template after comparing to some real world hCard templates from real pods. Old version was based on documentation in Diaspora project wiki.
 
 ## [0.3.2] - 2016-05-09
 

--- a/federation/fetchers.py
+++ b/federation/fetchers.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import importlib
+import warnings
+
+
+def retrieve_remote_profile(handle, protocol=None):
+    """High level retrieve profile method.
+
+    Retrieve the profile from a remote location, using either the given protocol or by checking each
+    protocol until a user can be constructed from the remote documents.
+
+    Currently, due to no other protocols supported, always use the Diaspora protocol.
+
+    Args:
+        handle (str) - The profile handle in format username@domain.tld
+    """
+    if protocol:
+        warnings.warn("Currently retrieve_remote_profile doesn't use the protocol argument. Diaspora protocol"
+                      "will always be used.")
+    protocol_name = "diaspora"
+    utils = importlib.import_module("federation.utils.%s" % protocol_name)
+    return utils.retrieve_and_parse_profile(handle)

--- a/federation/hostmeta/generators.py
+++ b/federation/hostmeta/generators.py
@@ -163,7 +163,7 @@ class DiasporaHCard(object):
     """
 
     required = [
-        "hostname", "fullname", "firstname", "lastname", "photo300", "photo100", "photo50", "searchable",
+        "hostname", "fullname", "firstname", "lastname", "photo300", "photo100", "photo50", "searchable", "guid", "public_key", "username",
     ]
 
     def __init__(self, **kwargs):

--- a/federation/hostmeta/templates/hcard_diaspora.html
+++ b/federation/hostmeta/templates/hcard_diaspora.html
@@ -1,62 +1,83 @@
-<div id='content'>
-    <h1>$fullname</h1>
-    <div id='content_inner'>
-        <div class='entity_profile vcard author' id='i'>
-            <h2>User profile</h2>
-            <dl class='entity_nickname'>
-                <dt>Nickname</dt>
-                <dd>
-                    <a class='nickname url uid' href='$hostname' rel='me'>$fullname</a>
-                </dd>
-            </dl>
-            <dl class='entity_given_name'>
-                <dt>First name</dt>
-                <dd>
-                    <span class='given_name'>$firstname</span>
-                </dd>
-            </dl>
-            <dl class='entity_family_name'>
-                <dt>Family name</dt>
-                <dd>
-                    <span class='family_name'>$lastname</span>
-                </dd>
-            </dl>
-            <dl class='entity_fn'>
-                <dt>Full name</dt>
-                <dd>
-                    <span class='fn'>$fullname</span>
-                </dd>
-            </dl>
-            <dl class='entity_url'>
-                <dt>URL</dt>
-                <dd>
-                    <a class='url' href='$hostname' id='pod_location' rel='me'>$hostname</a>
-                </dd>
-            </dl>
-            <dl class='entity_photo'>
-                <dt>Photo</dt>
-                <dd>
-                    <img class='photo avatar' height='300px' src='$photo300' width='300px'>
-                </dd>
-            </dl>
-            <dl class='entity_photo_medium'>
-                <dt>Photo</dt>
-                <dd>
-                    <img class='photo avatar' height='100px' src='$photo100' width='100px'>
-                </dd>
-            </dl>
-            <dl class='entity_photo_small'>
-                <dt>Photo</dt>
-                <dd>
-                    <img class='photo avatar' height='50px' src='$photo50' width='50px'>
-                </dd>
-            </dl>
-            <dl class='entity_searchable'>
-                <dt>Searchable</dt>
-                <dd>
-                    <span class='searchable'>$searchable</span>
-                </dd>
-            </dl>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <meta charset="UTF-8" />
+        <title>$fullname</title>
+    </head>
+<body>
+    <div id='content'>
+        <h1>$fullname</h1>
+        <div id='content_inner'>
+            <div class='entity_profile vcard author' id='i'>
+                <h2>User profile</h2>
+                <dl class="entity_uid">
+                    <dt>Uid</dt>
+                    <dd>
+                        <span class="uid">$guid</span>
+                    </dd>
+                </dl>
+                <dl class='entity_nickname'>
+                    <dt>Nickname</dt>
+                    <dd>
+                        <span class="nickname">$username</span>
+                    </dd>
+                </dl>
+                <dl class='entity_first_name'>
+                    <dt>First name</dt>
+                    <dd>
+                        <span class='given_name'>$firstname</span>
+                    </dd>
+                </dl>
+                <dl class='entity_family_name'>
+                    <dt>Family name</dt>
+                    <dd>
+                        <span class='family_name'>$lastname</span>
+                    </dd>
+                </dl>
+                <dl class='entity_full_name'>
+                    <dt>Full name</dt>
+                    <dd>
+                        <span class='fn'>$fullname</span>
+                    </dd>
+                </dl>
+                <dl class='entity_url'>
+                    <dt>URL</dt>
+                    <dd>
+                        <a class='url' href='$hostname' id='pod_location' rel='me'>$hostname</a>
+                    </dd>
+                </dl>
+                <dl class='entity_photo'>
+                    <dt>Photo</dt>
+                    <dd>
+                        <img class='photo avatar' height='300px' src='$photo300' width='300px'>
+                    </dd>
+                </dl>
+                <dl class='entity_photo_medium'>
+                    <dt>Photo</dt>
+                    <dd>
+                        <img class='photo avatar' height='100px' src='$photo100' width='100px'>
+                    </dd>
+                </dl>
+                <dl class='entity_photo_small'>
+                    <dt>Photo</dt>
+                    <dd>
+                        <img class='photo avatar' height='50px' src='$photo50' width='50px'>
+                    </dd>
+                </dl>
+                <dl class='entity_searchable'>
+                    <dt>Searchable</dt>
+                    <dd>
+                        <span class='searchable'>$searchable</span>
+                    </dd>
+                </dl>
+                <dl class="entity_key">
+                    <dt>Key</dt>
+                    <dd>
+                        <pre class="key">$public_key
+</pre>
+                    </dd>
+                </dl>
+            </div>
         </div>
     </div>
-</div>
+</body>

--- a/federation/tests/hostmeta/test_generators.py
+++ b/federation/tests/hostmeta/test_generators.py
@@ -68,7 +68,10 @@ class TestDiasporaHCardGenerator(object):
             photo300="photo300",
             photo100="photo100",
             photo50="photo50",
-            searchable="searchable"
+            searchable="searchable",
+            guid="guid",
+            public_key="public_key",
+            username="username",
         )
         assert hcard == template
 
@@ -88,7 +91,7 @@ class TestDiasporaHCardGenerator(object):
                 hostname="hostname",
                 fullname="fullname",
                 firstname="firstname",
-                username="username"
+                unknown="unknown"
             )
 
 

--- a/federation/tests/test_fetchers.py
+++ b/federation/tests/test_fetchers.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import patch, Mock
+
+from federation.fetchers import retrieve_remote_profile
+
+
+class TestRetrieveRemoteProfile(object):
+    @patch("federation.fetchers.importlib.import_module")
+    def test_calls_diaspora_retrieve_and_parse_profile(self, mock_import):
+        class MockRetrieve(Mock):
+            def retrieve_and_parse_profile(self, handle):
+                return "called with %s" % handle
+
+        mock_retrieve = MockRetrieve()
+        mock_import.return_value = mock_retrieve
+        assert retrieve_remote_profile("foo@bar") == "called with foo@bar"

--- a/federation/tests/utils/test_diaspora.py
+++ b/federation/tests/utils/test_diaspora.py
@@ -2,8 +2,11 @@
 from unittest.mock import patch
 from urllib.parse import quote
 
-from federation.hostmeta.generators import DiasporaWebFinger, DiasporaHostMeta
-from federation.utils.diaspora import retrieve_diaspora_hcard, retrieve_diaspora_webfinger, retrieve_diaspora_host_meta
+from lxml import html
+
+from federation.hostmeta.generators import DiasporaWebFinger, DiasporaHostMeta, DiasporaHCard, generate_hcard
+from federation.utils.diaspora import retrieve_diaspora_hcard, retrieve_diaspora_webfinger, retrieve_diaspora_host_meta, \
+    _get_element_text_or_none, _get_element_attr_or_none, parse_profile_from_hcard, retrieve_and_parse_profile
 
 
 class TestRetrieveDiasporaHCard(object):
@@ -82,3 +85,81 @@ class TestRetrieveDiasporaHostMeta(object):
         document = retrieve_diaspora_host_meta("localhost")
         mock_fetch.assert_called_with(host="localhost", path="/.well-known/host-meta")
         assert document == None
+
+
+class TestGetElementTextOrNone(object):
+    doc = html.fromstring("<foo>bar</foo>")
+
+    def test_text_returned_on_element(self):
+        assert _get_element_text_or_none(self.doc, "foo") == "bar"
+
+    def test_none_returned_on_no_element(self):
+        assert _get_element_text_or_none(self.doc, "bar") == None
+
+
+class TestGetElementAttrOrNone(object):
+    doc = html.fromstring("<foo src='baz'>bar</foo>")
+
+    def test_attr_returned_on_attr(self):
+        assert _get_element_attr_or_none(self.doc, "foo", "src") == "baz"
+
+    def test_none_returned_on_attr(self):
+        assert _get_element_attr_or_none(self.doc, "foo", "href") == None
+
+    def test_none_returned_on_no_element(self):
+        assert _get_element_attr_or_none(self.doc, "bar", "href") == None
+
+
+class TestParseProfileFromHCard(object):
+    def test_profile_is_parsed(self):
+        hcard = generate_hcard(
+            "diaspora",
+            hostname="https://hostname",
+            fullname="fullname",
+            firstname="firstname",
+            lastname="lastname",
+            photo300="photo300",
+            photo100="photo100",
+            photo50="photo50",
+            searchable="true",
+            guid="guid",
+            public_key="public_key",
+            username="username",
+        )
+        profile = parse_profile_from_hcard(hcard)
+        assert profile.name == "fullname"
+        assert profile.image_urls == {
+            "small": "photo50", "medium": "photo100", "large": "photo300"
+        }
+        assert profile.public == True
+        assert profile.handle == "username@hostname"
+        assert profile.guid == "guid"
+        assert profile.public_key == "public_key\n"
+
+
+class TestRetrieveAndParseProfile(object):
+    @patch("federation.utils.diaspora.retrieve_diaspora_hcard", return_value=None)
+    def test_retrieve_diaspora_hcard_is_called(self, mock_retrieve):
+        retrieve_and_parse_profile("foo@bar")
+        mock_retrieve.assert_called_with("foo@bar")
+
+    @patch("federation.utils.diaspora.parse_profile_from_hcard")
+    @patch("federation.utils.diaspora.retrieve_diaspora_hcard")
+    def test_parse_profile_from_hcard_called(self, mock_retrieve, mock_parse):
+        hcard = generate_hcard(
+            "diaspora",
+            hostname="https://hostname",
+            fullname="fullname",
+            firstname="firstname",
+            lastname="lastname",
+            photo300="photo300",
+            photo100="photo100",
+            photo50="photo50",
+            searchable="true",
+            guid="guid",
+            public_key="public_key",
+            username="username",
+        )
+        mock_retrieve.return_value = hcard
+        retrieve_and_parse_profile("foo@bar")
+        mock_parse.assert_called_with(hcard)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     packages=find_packages(),
     license="BSD 3-clause",
     install_requires=[
+        "cssselect>=0.9.2",
         "dirty-validators>=0.3.0, <0.4.0",
         "lxml>=3.4.0, <4.0.0",
         "jsonschema>=2.0.0, <3.0.0",


### PR DESCRIPTION
High level method to fetch a remote profile. Currently falls back to Diaspora protocol as no others are supported.

Returns a Profile entity.

Closes #15

Also add 'guid' and 'public_key' as required for DiasporaHCard generator. Leaving these out was a mistake in the initial implementation. Diaspora has these in at least 0.6 development branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaywink/social-federation/36)
<!-- Reviewable:end -->
