### PR TITLE
Make to_user optional in handle_create_payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [unreleased]
+
+## Breaking changes
+- `federation.outbound.handle_create_payload` parameter `to_user` is now optional. Public posts don't need a recipient. This also affects Diaspora protocol `build_send` method where the change is reflected similarly. [#43](https://github.com/jaywink/social-federation/pull/43)
+     - In practise this means the signature has changed for `handle_create_payload` and `build_send` from **`from_user, to_user, entity`** to **`entity, from_user, to_user=None`**.
+
 ## [0.4.1] - 2016-09-04
 
 ## Fixes

--- a/federation/outbound.py
+++ b/federation/outbound.py
@@ -3,16 +3,16 @@ from federation.entities.diaspora.mappers import get_outbound_entity
 from federation.protocols.diaspora.protocol import Protocol
 
 
-def handle_create_payload(from_user, to_user, entity):
+def handle_create_payload(entity, from_user, to_user=None):
     """Create a payload with the correct protocol.
 
     Since we don't know the protocol, we need to first query the recipient. However, for a PoC implementation,
     supporting only Diaspora, we're going to assume that for now.
 
     Args:
-        from_user (obj)     - User sending the object
-        to_user (obj)       - Contact entry to send to
         entity (obj)        - Entity object to send
+        from_user (obj)     - User sending the object
+        to_user (obj)       - Contact entry to send to (required for non-public content)
 
     `from_user` must have `private_key` and `handle` attributes.
     `to_user` must have `key` attribute.
@@ -20,5 +20,5 @@ def handle_create_payload(from_user, to_user, entity):
     # Just use Diaspora protocol for now
     protocol = Protocol()
     outbound_entity = get_outbound_entity(entity)
-    data = protocol.build_send(from_user=from_user, to_user=to_user, entity=outbound_entity)
+    data = protocol.build_send(entity=outbound_entity, from_user=from_user, to_user=to_user)
     return data

--- a/federation/tests/protocols/diaspora/test_diaspora.py
+++ b/federation/tests/protocols/diaspora/test_diaspora.py
@@ -150,6 +150,6 @@ class TestDiasporaProtocol(DiasporaTestBase):
         mock_entity_xml = Mock()
         entity = Mock(to_xml=Mock(return_value=mock_entity_xml))
         from_user = Mock(handle="foobar", private_key="barfoo")
-        data = protocol.build_send(from_user, Mock(), entity)
+        data = protocol.build_send(entity, from_user)
         mock_init_message.assert_called_once_with(mock_entity_xml, from_user.handle, from_user.private_key)
         assert data == {"xml": "xmldata"}

--- a/federation/tests/test_outbound.py
+++ b/federation/tests/test_outbound.py
@@ -13,16 +13,14 @@ class TestHandleCreatePayloadBuildsAPayload(object):
         mock_protocol = Mock()
         mock_protocol_class.return_value = mock_protocol
         from_user = Mock()
-        to_user = Mock()
         entity = DiasporaPost()
-        handle_create_payload(from_user, to_user, entity)
-        mock_protocol.build_send.assert_called_once_with(from_user=from_user, to_user=to_user, entity=entity)
+        handle_create_payload(entity, from_user)
+        mock_protocol.build_send.assert_called_once_with(entity=entity, from_user=from_user, to_user=None)
 
     @patch("federation.outbound.get_outbound_entity")
     def test_handle_create_payload_calls_get_outbound_entity(self, mock_get_outbound_entity):
         mock_get_outbound_entity.return_value = DiasporaPost()
         from_user = Mock(private_key=RSA.generate(2048), handle="foobar@domain.tld")
-        to_user = Mock(key=RSA.generate(2048).publickey())
         entity = DiasporaPost()
-        handle_create_payload(from_user, to_user, entity)
+        handle_create_payload(entity, from_user)
         assert mock_get_outbound_entity.called


### PR DESCRIPTION
Public content does not require a recipient.