### PR TITLE
Fix new style Diaspora Magic Envelope payload data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [unreleased]
+
+### Fixed
+* New style Diaspora Magic Envelope didn't require or like payload data to be cut to 60 char lines, as the legacy protocol does. Fixed to not cut lines.
+
 ## [0.6.0] - 2016-09-13
 
 ### Added

--- a/federation/tests/protocols/diaspora/test_magic_envelope.py
+++ b/federation/tests/protocols/diaspora/test_magic_envelope.py
@@ -30,7 +30,8 @@ class TestMagicEnvelope(object):
             wrap_payload=True,
         )
         payload = env.create_payload()
-        assert payload == b"<XML><post><status_message><foo>bar</foo></status_message></post></XML>"
+        assert payload == "PFhNTD48cG9zdD48c3RhdHVzX21lc3NhZ2U-PGZvbz5iYXI8L2Zvbz48L3N0YXR1c19tZXNzYWdlPjwvcG9zdD4" \
+                          "8L1hNTD4="
 
     def test_create_payload(self):
         env = MagicEnvelope(
@@ -39,17 +40,7 @@ class TestMagicEnvelope(object):
             author_handle="foobar@example.com"
         )
         payload = env.create_payload()
-        assert payload == b"<status_message><foo>bar</foo></status_message>"
-
-    def test_encode_payload(self):
-        env = MagicEnvelope(
-            message="<status_message><foo>bar</foo></status_message>",
-            private_key="key",
-            author_handle="foobar@example.com"
-        )
-        env.create_payload()
-        payload = env._encode_payload()
-        assert payload == "PHN0YXR1c19tZXNzYWdlPjxmb28-YmFyPC9mb28-PC9zdGF0dXNfbWVzc2Fn\nZT4=\n"
+        assert payload == "PHN0YXR1c19tZXNzYWdlPjxmb28-YmFyPC9mb28-PC9zdGF0dXNfbWVzc2FnZT4="
 
     def test_build_signature(self):
         env = MagicEnvelope(
@@ -58,14 +49,12 @@ class TestMagicEnvelope(object):
             author_handle="foobar@example.com"
         )
         env.create_payload()
-        env._encode_payload()
         signature, key_id = env._build_signature()
-        assert signature == b"RAfiBBrk0OzPbmh6xE7wMRe7ir-qprZ7zk5VDGfopc6rfATFNbNB2FWH" \
-                            b"FdvJfoky9ORNvfUoiFmtbMG7kmmFHgpQdUl_OU81lKb7NG6-aq2ZRVDQ" \
-                            b"T46UYat1ssdqkkynqywowdyEGVUxxalFkOHWuYajmpc7ajt_G8xXjMDU" \
-                            b"Ctt0VUFXepxshd24ZWRXO1RQK4bFr7X9-d26Ho3kLuB1VB_pYYbxJQCZl" \
-                            b"m0EDlFj7vktl0zibswMFyRqiacwu8zec_HR4x8yMkF_zSNJsnnLq6ch4ad6" \
-                            b"r83LOVk3Yvdxinb61spHEjr2zvPWExEgUt4Jcpc07aZRUKCJVfFXFYAGnA=="
+        assert signature == b'Cmk08MR4Tp8r9eVybD1hORcR_8NLRVxAu0biOfJbkI1xLx1c480zJ720cpVyKaF9CxVjW3lvlvRz' \
+                            b'5YbswMv0izPzfHpXoWTXH-4UPrXaGYyJnrNvqEB2UWn4iHKJ2Rerto8sJY2b95qbXD6Nq75EoBNu' \
+                            b'b5P7DYc16ENhp38YwBRnrBEvNOewddpOpEBVobyNB7no_QR8c_xkXie-hUDFNwI0z7vax9HkaBFb' \
+                            b'vEmzFPMZAAdWyjxeGiWiqY0t2ZdZRCPTezy66X6Q0qc4I8kfT-Mt1ctjGmNMoJ4Lgu-PrO5hSRT4' \
+                            b'QBAVyxaog5w-B0PIPuC-mUW5SZLsnX3_ZuwJww=='
         assert key_id == b"Zm9vYmFyQGV4YW1wbGUuY29t"
 
     def test_render(self):
@@ -76,17 +65,14 @@ class TestMagicEnvelope(object):
         )
         env.build()
         output = env.render()
-        assert output == '<me:env xmlns:me="http://salmon-protocol.org/ns/magic-env">' \
-                         '<me:encoding>base64url</me:encoding><me:alg>RSA-SHA256</me:alg>' \
-                         '<me:data type="application/xml">PHN0YXR1c19tZXNzYWdlPjxmb28-Ym' \
-                         'FyPC9mb28-PC9zdGF0dXNfbWVzc2Fn\nZT4=\n</me:data>' \
-                         '<me:sig key_id="Zm9vYmFyQGV4YW1wbGUuY29t">RAfiBBrk0OzPbmh6xE7wMRe' \
-                         '7ir-qprZ7zk5VDGfopc6rfATFNbNB2FWHFdvJfoky9ORNvfUoiFmtbMG7kmmFHgp' \
-                         'QdUl_OU81lKb7NG6-aq2ZRVDQT46UYat1ssdqkkynqywo' \
-                         'wdyEGVUxxalFkOHWuYajmpc7ajt_G8xXjMDUCtt0VUFXepxshd24ZWRX' \
-                         'O1RQK4bFr7X9-d26Ho3kLuB1VB_pYYbxJQCZlm0EDlFj7vktl0zibs' \
-                         'wMFyRqiacwu8zec_HR4x8yMkF_zSNJsnnLq6ch4ad6r83LOVk3Yvdxin' \
-                         'b61spHEjr2zvPWExEgUt4Jcpc07aZRUKCJVfFXFYAGnA==</me:sig></me:env>'
+        assert output == '<me:env xmlns:me="http://salmon-protocol.org/ns/magic-env"><me:encoding>base64url' \
+                         '</me:encoding><me:alg>RSA-SHA256</me:alg><me:data type="application/xml">' \
+                         'PHN0YXR1c19tZXNzYWdlPjxmb28-YmFyPC9mb28-PC9zdGF0dXNfbWVzc2FnZT4=</me:data>' \
+                         '<me:sig key_id="Zm9vYmFyQGV4YW1wbGUuY29t">Cmk08MR4Tp8r9eVybD1hORcR_8NLRVxAu0biOfJbk' \
+                         'I1xLx1c480zJ720cpVyKaF9CxVjW3lvlvRz5YbswMv0izPzfHpXoWTXH-4UPrXaGYyJnrNvqEB2UWn4iHK' \
+                         'J2Rerto8sJY2b95qbXD6Nq75EoBNub5P7DYc16ENhp38YwBRnrBEvNOewddpOpEBVobyNB7no_QR8c_xkX' \
+                         'ie-hUDFNwI0z7vax9HkaBFbvEmzFPMZAAdWyjxeGiWiqY0t2ZdZRCPTezy66X6Q0qc4I8kfT-Mt1ctjGmNM' \
+                         'oJ4Lgu-PrO5hSRT4QBAVyxaog5w-B0PIPuC-mUW5SZLsnX3_ZuwJww==</me:sig></me:env>'
         env2 = MagicEnvelope(
             message="<status_message><foo>bar</foo></status_message>",
             private_key=get_dummy_private_key(),


### PR DESCRIPTION
New style Diaspora Magic Envelope didn't require or like payload data to be cut to 60 char lines, as the legacy protocol does. Fixed to not cut lines.