### PR TITLE
Fix parsing profile from hCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [unreleased]
+
+### Changed
+* Function `federation.utils.diaspora.parse_profile_from_hcard` now requires a second argument, `handle`. Since in the future Diaspora hCard is not guaranteed to have username and domain, we now pass handle to the parser directly.
+
 ## [0.6.1] - 2016-09-14
 
 ### Fixed

--- a/federation/tests/utils/test_diaspora.py
+++ b/federation/tests/utils/test_diaspora.py
@@ -126,7 +126,7 @@ class TestParseProfileFromHCard(object):
             public_key="public_key",
             username="username",
         )
-        profile = parse_profile_from_hcard(hcard)
+        profile = parse_profile_from_hcard(hcard, "username@hostname")
         assert profile.name == "fullname"
         assert profile.image_urls == {
             "small": "photo50", "medium": "photo100", "large": "photo300"
@@ -162,4 +162,4 @@ class TestRetrieveAndParseProfile(object):
         )
         mock_retrieve.return_value = hcard
         retrieve_and_parse_profile("foo@bar")
-        mock_parse.assert_called_with(hcard)
+        mock_parse.assert_called_with(hcard, "foo@bar")

--- a/federation/utils/diaspora.py
+++ b/federation/utils/diaspora.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 
 from lxml import html
 from xrd import XRD
@@ -95,15 +95,15 @@ def _get_element_attr_or_none(document, selector, attribute):
     return None
 
 
-def parse_profile_from_hcard(hcard):
+def parse_profile_from_hcard(hcard, handle):
     """
     Parse all the fields we can from a hCard document to get a Profile.
 
     Args:
          hcard (str) - HTML hcard document
+         handle (str) - User handle in username@domain.tld format
     """
     doc = html.fromstring(hcard)
-    domain = urlparse(_get_element_attr_or_none(doc, "a#pod_location", "href")).netloc
     profile = Profile(
         name=_get_element_text_or_none(doc, ".fn"),
         image_urls={
@@ -112,7 +112,7 @@ def parse_profile_from_hcard(hcard):
             "large": _get_element_attr_or_none(doc, ".entity_photo .photo", "src"),
         },
         public=True if _get_element_text_or_none(doc, ".searchable") == "true" else False,
-        handle="%s@%s" % (_get_element_text_or_none(doc, ".nickname"), domain),
+        handle=handle,
         guid=_get_element_text_or_none(doc, ".uid"),
         public_key=_get_element_text_or_none(doc, ".key"),
     )
@@ -132,4 +132,4 @@ def retrieve_and_parse_profile(handle):
     hcard = retrieve_diaspora_hcard(handle)
     if not hcard:
         return None
-    return parse_profile_from_hcard(hcard)
+    return parse_profile_from_hcard(hcard, handle)


### PR DESCRIPTION
In the future diaspora hCard is not guaranteed to contain pod url or username. Don't rely on these in the parser, instead pass handle to the hCard parser directly.

Closes #50