### PR TITLE
Various improvements to entity validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [unreleased]
 
+### Backwards incompatible changes
+* Made `guid` mandatory for `Profile` entity. Library users should always be able to get a full validated object as we consider `guid` a core attribute of a profile.
+* Always validate entities created through `federation.entities.diaspora.mappers.message_to_objects`. This is the code that transforms federation messages for the Diaspora protocol to actual entity objects. Previously no validation was done and callers of `federation.inbound.handle_receive` received entities that were not always valid, for example they were missing a `guid`. Now validation is done in the conversion stage and errors are pushed to the `social-federation` logger in the event of invalid messages.
+    * Note Diaspora Profile XML messages do not provide a GUID. This is handled internally by fetching the guid from the remote hCard so that a valid `Profile` entity can be created.
+
+### Added
+* Raise a warning if unknown parameters are passed to entities.
+* Ensure entity required attributes are validated for `None` or empty string values. Required attributes must not only exist but also have a value.
+* Add validation to entities with the attribute `public`. Only `bool` values are accepted.
+
 ### Changed
 * Function `federation.utils.diaspora.parse_profile_from_hcard` now requires a second argument, `handle`. Since in the future Diaspora hCard is not guaranteed to have username and domain, we now pass handle to the parser directly.
 

--- a/federation/entities/base.py
+++ b/federation/entities/base.py
@@ -229,11 +229,6 @@ class Profile(CreatedAtMixin, HandleMixin, RawContentMixin, PublicMixin, GUIDMix
     tag_list = []
     public_key = ""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Don't require a guid for Profile
-        self._required.remove("guid")
-
     def validate_email(self):
         if self.email:
             validator = Email()

--- a/federation/entities/base.py
+++ b/federation/entities/base.py
@@ -94,6 +94,10 @@ class HandleMixin(BaseEntity):
 class PublicMixin(BaseEntity):
     public = False
 
+    def validate_public(self):
+        if not isinstance(self.public, bool):
+            raise ValueError("Public is not valid - it should be True or False")
+
 
 class CreatedAtMixin(BaseEntity):
     created_at = datetime.datetime.now()

--- a/federation/entities/base.py
+++ b/federation/entities/base.py
@@ -5,9 +5,6 @@ import warnings
 from dirty_validators.basic import Email
 
 
-__all__ = ("Post", "Image", "Comment")
-
-
 class BaseEntity(object):
     _required = []
 

--- a/federation/entities/base.py
+++ b/federation/entities/base.py
@@ -74,7 +74,7 @@ class GUIDMixin(BaseEntity):
         self._required += ["guid"]
 
     def validate_guid(self):
-        if self.guid and len(self.guid) < 16:
+        if len(self.guid) < 16:
             raise ValueError("GUID must be at least 16 characters")
 
 

--- a/federation/entities/base.py
+++ b/federation/entities/base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
+import warnings
 
 from dirty_validators.basic import Email
 
@@ -15,6 +16,10 @@ class BaseEntity(object):
         for key, value in kwargs.items():
             if hasattr(self, key):
                 setattr(self, key, value)
+            else:
+                warnings.warn("%s.__init__ got parameter %s which this class does not support - ignoring." % (
+                    self.__class__.__name__, key
+                ))
 
     def validate(self):
         """Do validation.

--- a/federation/entities/base.py
+++ b/federation/entities/base.py
@@ -100,11 +100,13 @@ class PublicMixin(BaseEntity):
 
 
 class CreatedAtMixin(BaseEntity):
-    created_at = datetime.datetime.now()
+    created_at = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._required += ["created_at"]
+        if not "created_at" in kwargs:
+            self.created_at = datetime.datetime.now()
 
 
 class RawContentMixin(BaseEntity):

--- a/federation/tests/entities/diaspora/test_entities.py
+++ b/federation/tests/entities/diaspora/test_entities.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
+from unittest.mock import patch
+
+import pytest
 from lxml import etree
 
+from federation.entities.base import Profile
 from federation.entities.diaspora.entities import DiasporaComment, DiasporaPost, DiasporaLike, DiasporaRequest, \
     DiasporaProfile
 
@@ -61,3 +65,17 @@ class TestEntitiesConvertToXML(object):
                     b"<gender></gender><bio>foobar</bio><location></location><searchable>true</searchable>" \
                     b"<nsfw>false</nsfw><tag_string>#socialfederation #federation</tag_string></profile>"
         assert etree.tostring(result) == converted
+
+
+class TestDiasporaProfileFillExtraAttributes(object):
+    def test_raises_if_no_handle(self):
+        attrs = {"foo": "bar"}
+        with pytest.raises(ValueError):
+            DiasporaProfile.fill_extra_attributes(attrs)
+
+    @patch("federation.entities.diaspora.entities.retrieve_and_parse_profile")
+    def test_calls_retrieve_and_parse_profile(self, mock_retrieve):
+        mock_retrieve.return_value = Profile(guid="guidguidguidguid")
+        attrs = {"handle": "foo"}
+        attrs = DiasporaProfile.fill_extra_attributes(attrs)
+        assert attrs == {"handle": "foo", "guid": "guidguidguidguid"}

--- a/federation/tests/entities/test_base.py
+++ b/federation/tests/entities/test_base.py
@@ -3,7 +3,8 @@ from unittest.mock import Mock
 
 import pytest
 
-from federation.entities.base import BaseEntity, Relationship, Profile, RawContentMixin
+from federation.entities.base import BaseEntity, Relationship, Profile, RawContentMixin, GUIDMixin, HandleMixin, \
+    PublicMixin, Image
 from federation.tests.factories.entities import TaggedPostFactory, PostFactory
 
 
@@ -23,6 +24,27 @@ class TestBaseEntityCallsValidateMethods(object):
         post.validate_location = Mock()
         post.validate()
         assert post.validate_location.call_count == 1
+
+
+class TestGUIDMixinValidate(object):
+    def test_validate_guid_raises_on_low_length(self):
+        guid = GUIDMixin(guid="x"*15)
+        with pytest.raises(ValueError):
+            guid.validate()
+
+
+class TestHandleMixinValidate(object):
+    def test_validate_handle_raises_on_invalid_format(self):
+        handle = HandleMixin(handle="foobar")
+        with pytest.raises(ValueError):
+            handle.validate()
+
+
+class TestPublicMixinValidate(object):
+    def test_validate_public_raises_on_low_length(self):
+        public = PublicMixin(public="foobar")
+        with pytest.raises(ValueError):
+            public.validate()
 
 
 class TestEntityRequiredAttributes(object):
@@ -69,5 +91,25 @@ class TestProfileEntity(object):
 
     def test_guid_is_mandatory(self):
         entity = Profile(handle="bob@example.com", raw_content="foobar")
+        with pytest.raises(ValueError):
+            entity.validate()
+
+
+class TestImageEntity(object):
+    def test_instance_creation(self):
+        entity = Image(
+            guid="x"*16, handle="foo@example.com", public=False, remote_path="foobar", remote_name="barfoo"
+        )
+        entity.validate()
+
+    def test_required_fields(self):
+        entity = Image(
+            guid="x" * 16, handle="foo@example.com", public=False, remote_name="barfoo"
+        )
+        with pytest.raises(ValueError):
+            entity.validate()
+        entity = Image(
+            guid="x" * 16, handle="foo@example.com", public=False, remote_path="foobar"
+        )
         with pytest.raises(ValueError):
             entity.validate()

--- a/federation/tests/entities/test_base.py
+++ b/federation/tests/entities/test_base.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from federation.entities.base import BaseEntity, Relationship, Profile
+from federation.entities.base import BaseEntity, Relationship, Profile, RawContentMixin
 from federation.tests.factories.entities import TaggedPostFactory, PostFactory
 
 
@@ -29,6 +29,14 @@ class TestEntityRequiredAttributes(object):
     def test_entity_checks_for_required_attributes(self):
         entity = BaseEntity()
         entity._required = ["foobar"]
+        with pytest.raises(ValueError):
+            entity.validate()
+
+    def test_validate_checks_required_values_are_not_empty(self):
+        entity = RawContentMixin(raw_content=None)
+        with pytest.raises(ValueError):
+            entity.validate()
+        entity = RawContentMixin(raw_content="")
         with pytest.raises(ValueError):
             entity.validate()
 

--- a/federation/tests/entities/test_base.py
+++ b/federation/tests/entities/test_base.py
@@ -67,6 +67,7 @@ class TestProfileEntity(object):
             entity = Profile(handle="bob@example.com", raw_content="foobar", email="foobar")
             entity.validate()
 
-    def test_guid_is_not_mandatory(self):
+    def test_guid_is_mandatory(self):
         entity = Profile(handle="bob@example.com", raw_content="foobar")
-        entity.validate()
+        with pytest.raises(ValueError):
+            entity.validate()

--- a/federation/tests/fixtures/payloads.py
+++ b/federation/tests/fixtures/payloads.py
@@ -32,7 +32,20 @@ DIASPORA_POST_SIMPLE = """<XML>
       <post>
         <status_message>
           <raw_message>((status message))</raw_message>
-          <guid>((guid))</guid>
+          <guid>((guidguidguidguidguidguidguid))</guid>
+          <diaspora_handle>alice@alice.diaspora.example.org</diaspora_handle>
+          <public>false</public>
+          <created_at>2011-07-20 01:36:07 UTC</created_at>
+          <provider_display_name>Socialhome</provider_display_name>
+        </status_message>
+      </post>
+    </XML>
+"""
+
+DIASPORA_POST_INVALID = """<XML>
+      <post>
+        <status_message>
+          <raw_message>((status message))</raw_message>
           <diaspora_handle>alice@alice.diaspora.example.org</diaspora_handle>
           <public>false</public>
           <created_at>2011-07-20 01:36:07 UTC</created_at>
@@ -45,8 +58,8 @@ DIASPORA_POST_SIMPLE = """<XML>
 DIASPORA_POST_COMMENT = """<XML>
       <post>
         <comment>
-          <guid>((guid))</guid>
-          <parent_guid>((parent_guid))</parent_guid>
+          <guid>((guidguidguidguidguidguid))</guid>
+          <parent_guid>((parent_guidparent_guidparent_guidparent_guid))</parent_guid>
           <author_signature>((base64-encoded data))</author_signature>
           <text>((text))</text>
           <diaspora_handle>alice@alice.diaspora.example.org</diaspora_handle>
@@ -59,8 +72,8 @@ DIASPORA_POST_LIKE = """<XML>
       <post>
         <like>
           <target_type>Post</target_type>
-          <guid>((guid))</guid>
-          <parent_guid>((parent_guid))</parent_guid>
+          <guid>((guidguidguidguidguidguid))</guid>
+          <parent_guid>((parent_guidparent_guidparent_guidparent_guid))</parent_guid>
           <author_signature>((base64-encoded data))</author_signature>
           <positive>true</positive>
           <diaspora_handle>alice@alice.diaspora.example.org</diaspora_handle>


### PR DESCRIPTION
Changelog:

* Made `guid` mandatory for `Profile` entity. Library users should always be able to get a full validated object as we consider `guid` a core attribute of a profile.
* Always validate entities created through `federation.entities.diaspora.mappers.message_to_objects`. This is the code that transforms federation messages for the Diaspora protocol to actual entity objects. Previously no validation was done and callers of `federation.inbound.handle_receive` received entities that were not always valid, for example they were missing a `guid`. Now validation is done in the conversion stage and errors are pushed to the `social-federation` logger in the event of invalid messages.
    * Note Diaspora Profile XML messages do not provide a GUID. This is handled internally by fetching the guid from the remote hCard so that a valid `Profile` entity can be created.

* Raise a warning if unknown parameters are passed to entities.
* Ensure entity required attributes are validated for `None` or empty string values. Required attributes must not only exist but also have a value.
* Add validation to entities with the attribute `public`. Only `bool` values are accepted.