### PR TITLE
Validate fetched remote profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Backwards incompatible changes
 * `federation.utils.diaspora.retrieve_and_parse_profile` will now return `None` if the `Profile` retrieved doesn't validate. This will affect also the output of `federation.fetchers.retrieve_remote_profile` which is the high level function to retrieve profiles.
+* Remove unnecessary `protocol` parameter from `federation.fetchers.retrieve_remote_profile`. We're miles away from including other protocols and ideally the caller shouldn't have to pass in the protocol anyway.
 
 ### Added
 * Added `Retraction` entity with `DiasporaRetraction` counterpart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+### Backwards incompatible changes
+* `federation.utils.diaspora.retrieve_and_parse_profile` will now return `None` if the `Profile` retrieved doesn't validate. This will affect also the output of `federation.fetchers.retrieve_remote_profile` which is the high level function to retrieve profiles.
+
 ### Added
 * Added `Retraction` entity with `DiasporaRetraction` counterpart.
 

--- a/federation/fetchers.py
+++ b/federation/fetchers.py
@@ -13,6 +13,9 @@ def retrieve_remote_profile(handle, protocol=None):
 
     Args:
         handle (str) - The profile handle in format username@domain.tld
+
+    Returns:
+        Profile or None
     """
     if protocol:
         warnings.warn("Currently retrieve_remote_profile doesn't use the protocol argument. Diaspora protocol"

--- a/federation/fetchers.py
+++ b/federation/fetchers.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 import importlib
-import warnings
 
 
-def retrieve_remote_profile(handle, protocol=None):
+def retrieve_remote_profile(handle):
     """High level retrieve profile method.
 
     Retrieve the profile from a remote location, using either the given protocol or by checking each
@@ -17,9 +16,6 @@ def retrieve_remote_profile(handle, protocol=None):
     Returns:
         Profile or None
     """
-    if protocol:
-        warnings.warn("Currently retrieve_remote_profile doesn't use the protocol argument. Diaspora protocol"
-                      "will always be used.")
     protocol_name = "diaspora"
     utils = importlib.import_module("federation.utils.%s" % protocol_name)
     return utils.retrieve_and_parse_profile(handle)


### PR DESCRIPTION
* `federation.utils.diaspora.retrieve_and_parse_profile` will now return `None` if the `Profile` retrieved doesn't validate. This will affect also the output of `federation.fetchers.retrieve_remote_profile` which is the high level function to retrieve profiles.
* Remove unnecessary `protocol` parameter from `federation.fetchers.retrieve_remote_profile`. We're miles away from including other protocols and ideally the caller shouldn't have to pass in the protocol anyway.

Closes #54